### PR TITLE
Call ntpdate brute force.

### DIFF
--- a/baxter_seminar_helper/seminar.sh
+++ b/baxter_seminar_helper/seminar.sh
@@ -6,7 +6,7 @@ source `rospack find jsk_tools`/src/bashrc.ros
 type setrosmaster > /dev/null 2>&1
 if [ $? == 1 ]; then
    function rossetmaster() { # 自分のよく使うロボットのhostnameを入れる
-       local hostname=${1-"baxter-ros"}
+       local hostname=${1-"011402P0006.local"}
        local ros_port=${2-"11311"}
        export ROS_MASTER_URI=http://$hostname:$ros_port
        if [[ "${PS1}" =~ \[http://.*:.*\]\ (.*)$ ]] ; then
@@ -16,6 +16,12 @@ if [ $? == 1 ]; then
        echo -e "\e[1;31mset ROS_MASTER_URI to $ROS_MASTER_URI\e[m"
    }
 fi
+
+for (( i=1; i<=3; i++)) 
+do
+  echo "#${i} ntpdate call";
+  ntpdate -q 011402P0006.local;
+done
 
 rossetip
 


### PR DESCRIPTION
While https://github.com/tork-a/baxter_seminar/pull/17 is not yet mergeable, this PR might be ok. The error at the last line is negligible IMO.
ntpdate repeats 3 times for better approximation.

```
$ rosrun baxter_seminar_helper seminar.sh
#1 ntpdate call
server 192.168.11.7, stratum 3, offset 0.027183, delay 0.02657
26 Jan 17:14:09 ntpdate[13048]: adjust time server 192.168.11.7 offset 0.027983 sec
#2 ntpdate call
server 192.168.11.7, stratum 3, offset 0.027425, delay 0.02650
26 Jan 17:14:15 ntpdate[13049]: adjust time server 192.168.11.7 offset 0.027525 sec
#3 ntpdate call
server 192.168.11.7, stratum 3, offset 0.027317, delay 0.02628
26 Jan 17:14:21 ntpdate[13060]: adjust time server 192.168.11.7 offset 0.027317 sec
set ROS_IP and ROS_HOSTNAME to 192.168.11.6
/opt/ros/indigo/share/jsk_tools/src/bashrc.ros: line 60: rossetrobot: command not found
```